### PR TITLE
Set Shop Now buttons to black

### DIFF
--- a/src/sections/Hero.jsx
+++ b/src/sections/Hero.jsx
@@ -29,7 +29,13 @@ const Hero = () => {
           Discover stylish Nike arrivals, quality comfort, and innovation for
           your active life.
         </p>
-        <Button label="Shop now" iconURL={arrowRight} />
+        <Button
+          label="Shop now"
+          iconURL={arrowRight}
+          backgroundColor="bg-black"
+          borderColor="border-black"
+          textColor="text-white"
+        />
         <div className="flex justify-start items-start flex-wrap w-full mt-20 gap-16">
           {statistics.map((stat) => (
             <div key={stat.label}>

--- a/src/sections/SpecialOffer.jsx
+++ b/src/sections/SpecialOffer.jsx
@@ -30,7 +30,13 @@ const SpecialOffer = () => {
           nothing short of exceptional.
         </p>
         <div className="mt-11 flex flex-wrap gap-4">
-          <Button label="Shop now" iconURL={arrowRight} />
+          <Button
+            label="Shop now"
+            iconURL={arrowRight}
+            backgroundColor="bg-black"
+            borderColor="border-black"
+            textColor="text-white"
+          />
           <Button
             label="Learn more"
             backgroundColor="bg-white"


### PR DESCRIPTION
## Summary
- make the main CTA buttons black instead of coral-red

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ba8e12914832bb1d7bccac91d99e5